### PR TITLE
feat: standard json api response; fluent validaction; Implement email…

### DIFF
--- a/DotNetEcuador.API/Controllers/BaseApiController.cs
+++ b/DotNetEcuador.API/Controllers/BaseApiController.cs
@@ -1,6 +1,8 @@
 using Asp.Versioning;
 using DotNetEcuador.API.Services;
+using DotNetEcuador.API.Models.Common;
 using Microsoft.AspNetCore.Mvc;
+using System.Diagnostics;
 
 namespace DotNetEcuador.API.Controllers;
 
@@ -19,4 +21,67 @@ public abstract class BaseApiController : ControllerBase
 
     protected string GetMessage(string key) => MessageService.GetMessage(key);
     protected string GetMessage(string key, params object[] args) => MessageService.GetMessage(key, args);
+
+    // Standard API Response Methods
+    protected IActionResult SuccessResponse<T>(T data, string message = "")
+    {
+        var response = new ApiResponse<T>
+        {
+            Success = true,
+            Data = data,
+            Message = string.IsNullOrEmpty(message) ? "Operación completada exitosamente" : message
+        };
+        return Ok(response);
+    }
+
+    protected IActionResult SuccessResponse(string message = "")
+    {
+        var response = new ApiResponse
+        {
+            Success = true,
+            Message = string.IsNullOrEmpty(message) ? "Operación completada exitosamente" : message
+        };
+        return Ok(response);
+    }
+
+    protected ActionResult BusinessError(string code, string message, int statusCode = 400)
+    {
+        var traceId = Activity.Current?.Id ?? HttpContext.TraceIdentifier;
+        var apiError = ApiError.BusinessError(code, message, HttpContext.Request.Path, statusCode, traceId);
+        return StatusCode(statusCode, apiError);
+    }
+
+    protected ActionResult ValidationErrors()
+    {
+        if (ModelState.IsValid)
+        {
+            return BadRequest("No validation errors found");
+        }
+
+        var errors = ModelState
+            .Where(x => x.Value?.Errors.Count > 0)
+            .ToDictionary(
+                kvp => kvp.Key,
+                kvp => kvp.Value?.Errors.Select(e => e.ErrorMessage).ToArray() ?? Array.Empty<string>()
+            );
+
+        var traceId = Activity.Current?.Id ?? HttpContext.TraceIdentifier;
+        var apiError = ApiError.ValidationError(HttpContext.Request.Path, errors, traceId);
+        return BadRequest(apiError);
+    }
+
+    protected ActionResult NotFoundError(string message = "Recurso no encontrado")
+    {
+        return BusinessError("not-found", message, 404);
+    }
+
+    protected ActionResult UnauthorizedError(string message = "No autorizado")
+    {
+        return BusinessError("unauthorized", message, 401);
+    }
+
+    protected ActionResult ForbiddenError(string message = "Acceso prohibido")
+    {
+        return BusinessError("forbidden", message, 403);
+    }
 }

--- a/DotNetEcuador.API/DotNetEcuador.API.csproj
+++ b/DotNetEcuador.API/DotNetEcuador.API.csproj
@@ -25,6 +25,9 @@
     <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.0.0" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.2.1" />
+    <PackageReference Include="FluentValidation" Version="11.8.1" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.8.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DotNetEcuador.API/Exceptions/DuplicateEmailException.cs
+++ b/DotNetEcuador.API/Exceptions/DuplicateEmailException.cs
@@ -1,0 +1,24 @@
+namespace DotNetEcuador.API.Exceptions;
+
+public class DuplicateEmailException : Exception
+{
+    public string Email { get; }
+    
+    public DuplicateEmailException(string email) 
+        : base($"Ya existe una aplicación de voluntario registrada con el email: {email}")
+    {
+        Email = email;
+    }
+    
+    public DuplicateEmailException(string email, string message) 
+        : base(message)
+    {
+        Email = email;
+    }
+    
+    public DuplicateEmailException(string email, string message, Exception innerException) 
+        : base(message, innerException)
+    {
+        Email = email;
+    }
+}

--- a/DotNetEcuador.API/Filters/ValidationActionFilter.cs
+++ b/DotNetEcuador.API/Filters/ValidationActionFilter.cs
@@ -1,0 +1,31 @@
+using DotNetEcuador.API.Models.Common;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using System.Diagnostics;
+
+namespace DotNetEcuador.API.Filters;
+
+public class ValidationActionFilter : ActionFilterAttribute
+{
+    public override void OnActionExecuting(ActionExecutingContext context)
+    {
+        if (!context.ModelState.IsValid)
+        {
+            var errors = context.ModelState
+                .Where(x => x.Value?.Errors.Count > 0)
+                .ToDictionary(
+                    kvp => kvp.Key,
+                    kvp => kvp.Value?.Errors.Select(e => e.ErrorMessage).ToArray() ?? Array.Empty<string>()
+                );
+
+            var traceId = Activity.Current?.Id ?? context.HttpContext.TraceIdentifier;
+            var apiError = ApiError.ValidationError(
+                context.HttpContext.Request.Path,
+                errors,
+                traceId
+            );
+
+            context.Result = new BadRequestObjectResult(apiError);
+        }
+    }
+}

--- a/DotNetEcuador.API/Infraestructure/Services/IVolunteerApplicationService.cs
+++ b/DotNetEcuador.API/Infraestructure/Services/IVolunteerApplicationService.cs
@@ -6,7 +6,7 @@ namespace DotNetEcuador.API.Infraestructure.Services;
 public interface IVolunteerApplicationService
 {
     Task CreateAsync(VolunteerApplication volunteerApplication);
-    bool AreValidAreasOfInterest(List<string> selectedAreas);
     Task<PagedResponse<VolunteerApplication>> GetAllAsync(PagedRequest request);
     Task<PagedResponse<VolunteerApplication>> SearchAsync(PagedRequest request, string searchTerm);
+    Task<VolunteerApplication?> GetByEmailAsync(string email);
 }

--- a/DotNetEcuador.API/Middleware/GlobalExceptionMiddleware.cs
+++ b/DotNetEcuador.API/Middleware/GlobalExceptionMiddleware.cs
@@ -1,0 +1,94 @@
+using DotNetEcuador.API.Exceptions;
+using DotNetEcuador.API.Models.Common;
+using System.Diagnostics;
+using System.Net;
+using System.Text.Json;
+
+namespace DotNetEcuador.API.Middleware;
+
+public class GlobalExceptionMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<GlobalExceptionMiddleware> _logger;
+    private readonly IWebHostEnvironment _environment;
+
+    public GlobalExceptionMiddleware(
+        RequestDelegate next,
+        ILogger<GlobalExceptionMiddleware> logger,
+        IWebHostEnvironment environment)
+    {
+        _next = next;
+        _logger = logger;
+        _environment = environment;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        try
+        {
+            await _next(context);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An unhandled exception occurred");
+            await HandleExceptionAsync(context, ex);
+        }
+    }
+
+    private async Task HandleExceptionAsync(HttpContext context, Exception exception)
+    {
+        var traceId = Activity.Current?.Id ?? context.TraceIdentifier;
+        var response = context.Response;
+
+        response.ContentType = "application/json";
+
+        ApiError apiError = exception switch
+        {
+            DuplicateEmailException ex => ApiError.BusinessError(
+                "duplicate-email",
+                ex.Message,
+                context.Request.Path,
+                409,
+                traceId),
+
+            UnauthorizedAccessException _ => ApiError.BusinessError(
+                "unauthorized", 
+                exception.Message, 
+                context.Request.Path, 
+                401, 
+                traceId),
+            
+            ArgumentException _ => ApiError.BusinessError(
+                "invalid-argument", 
+                exception.Message, 
+                context.Request.Path, 
+                400, 
+                traceId),
+                
+            InvalidOperationException _ => ApiError.BusinessError(
+                "invalid-operation", 
+                exception.Message, 
+                context.Request.Path, 
+                400, 
+                traceId),
+                
+            _ => ApiError.ServerError(
+                _environment.IsDevelopment() 
+                    ? exception.Message 
+                    : "Ha ocurrido un error interno del servidor.",
+                context.Request.Path,
+                traceId)
+        };
+
+        response.StatusCode = apiError.Status ?? 500;
+
+        var jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = true
+        };
+
+        var jsonResponse = JsonSerializer.Serialize(apiError, jsonOptions);
+        await response.WriteAsync(jsonResponse);
+    }
+}

--- a/DotNetEcuador.API/Models/Auth/LoginRequest.cs
+++ b/DotNetEcuador.API/Models/Auth/LoginRequest.cs
@@ -1,14 +1,7 @@
-using System.ComponentModel.DataAnnotations;
-
 namespace DotNetEcuador.API.Models.Auth;
 
 public class LoginRequest
 {
-    [Required(ErrorMessage = "El email es requerido")]
-    [EmailAddress(ErrorMessage = "El email debe tener un formato válido")]
     public string Email { get; set; } = string.Empty;
-
-    [Required(ErrorMessage = "La contraseña es requerida")]
-    [MinLength(6, ErrorMessage = "La contraseña debe tener al menos 6 caracteres")]
     public string Password { get; set; } = string.Empty;
 }

--- a/DotNetEcuador.API/Models/Auth/RegisterRequest.cs
+++ b/DotNetEcuador.API/Models/Auth/RegisterRequest.cs
@@ -1,25 +1,9 @@
-using System.ComponentModel.DataAnnotations;
-
 namespace DotNetEcuador.API.Models.Auth;
 
 public class RegisterRequest
 {
-    [Required(ErrorMessage = "El nombre completo es requerido")]
-    [MinLength(3, ErrorMessage = "El nombre debe tener al menos 3 caracteres")]
-    [MaxLength(100, ErrorMessage = "El nombre no puede exceder los 100 caracteres")]
     public string FullName { get; set; } = string.Empty;
-
-    [Required(ErrorMessage = "El email es requerido")]
-    [EmailAddress(ErrorMessage = "El email debe tener un formato válido")]
     public string Email { get; set; } = string.Empty;
-
-    [Required(ErrorMessage = "La contraseña es requerida")]
-    [MinLength(8, ErrorMessage = "La contraseña debe tener al menos 8 caracteres")]
-    [RegularExpression(@"^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).+$", 
-        ErrorMessage = "La contraseña debe contener al menos una mayúscula, una minúscula y un número")]
     public string Password { get; set; } = string.Empty;
-
-    [Required(ErrorMessage = "La confirmación de contraseña es requerida")]
-    [Compare("Password", ErrorMessage = "Las contraseñas no coinciden")]
     public string ConfirmPassword { get; set; } = string.Empty;
 }

--- a/DotNetEcuador.API/Models/Common/ApiError.cs
+++ b/DotNetEcuador.API/Models/Common/ApiError.cs
@@ -1,0 +1,55 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace DotNetEcuador.API.Models.Common;
+
+public class ApiError : ProblemDetails
+{
+    public Dictionary<string, string[]> Errors { get; set; } = new();
+    public string TraceId { get; set; } = string.Empty;
+    public DateTime Timestamp { get; set; } = DateTime.UtcNow;
+
+    public ApiError()
+    {
+        Type = "https://api.dotnetecuador.org/problems/error";
+    }
+
+    public static ApiError ValidationError(string instance, Dictionary<string, string[]> errors, string? traceId = null)
+    {
+        return new ApiError
+        {
+            Type = "https://api.dotnetecuador.org/problems/validation-error",
+            Title = "Error de Validación",
+            Status = 400,
+            Detail = "Se encontraron uno o más errores de validación.",
+            Instance = instance,
+            Errors = errors,
+            TraceId = traceId ?? string.Empty
+        };
+    }
+
+    public static ApiError BusinessError(string code, string message, string instance, int status = 400, string? traceId = null)
+    {
+        return new ApiError
+        {
+            Type = $"https://api.dotnetecuador.org/problems/{code}",
+            Title = "Error de Negocio",
+            Status = status,
+            Detail = message,
+            Instance = instance,
+            TraceId = traceId ?? string.Empty
+        };
+    }
+
+    public static ApiError ServerError(string message, string instance, string? traceId = null)
+    {
+        return new ApiError
+        {
+            Type = "https://api.dotnetecuador.org/problems/server-error",
+            Title = "Error del Servidor",
+            Status = 500,
+            Detail = message,
+            Instance = instance,
+            TraceId = traceId ?? string.Empty
+        };
+    }
+}

--- a/DotNetEcuador.API/Models/Common/ApiResponse.cs
+++ b/DotNetEcuador.API/Models/Common/ApiResponse.cs
@@ -1,0 +1,13 @@
+namespace DotNetEcuador.API.Models.Common;
+
+public class ApiResponse<T>
+{
+    public bool Success { get; set; } = true;
+    public T? Data { get; set; }
+    public string Message { get; set; } = string.Empty;
+    public DateTime Timestamp { get; set; } = DateTime.UtcNow;
+}
+
+public class ApiResponse : ApiResponse<object>
+{
+}

--- a/DotNetEcuador.API/Models/Common/PagedRequest.cs
+++ b/DotNetEcuador.API/Models/Common/PagedRequest.cs
@@ -1,19 +1,11 @@
-using System.ComponentModel.DataAnnotations;
-
 namespace DotNetEcuador.API.Models.Common;
 
 public class PagedRequest
 {
-    [Range(1, int.MaxValue, ErrorMessage = "Page debe ser mayor a 0")]
     public int Page { get; set; } = 1;
-
-    [Range(1, 100, ErrorMessage = "PageSize debe estar entre 1 y 100")]
     public int PageSize { get; set; } = 10;
-
     public string? SortBy { get; set; }
-
     public string? SortOrder { get; set; } = "asc";
-
     public string? Search { get; set; }
 
     public int Skip => (Page - 1) * PageSize;

--- a/DotNetEcuador.API/Models/VolunteerApplication.cs
+++ b/DotNetEcuador.API/Models/VolunteerApplication.cs
@@ -17,14 +17,5 @@ namespace DotNetEcuador.API.Models
         public string WhyVolunteer { get; set; } = string.Empty;
         public string AdditionalComments { get; set; } = string.Empty;
 
-        public bool ValidateOtherAreas()
-        {
-            if (AreasOfInterest.Contains("Other") && string.IsNullOrWhiteSpace(OtherAreas))
-            {
-                return false;
-            }
-
-            return true;
-        }
     }
 }

--- a/DotNetEcuador.API/Validators/Auth/LoginRequestValidator.cs
+++ b/DotNetEcuador.API/Validators/Auth/LoginRequestValidator.cs
@@ -1,0 +1,24 @@
+using DotNetEcuador.API.Models.Auth;
+using FluentValidation;
+
+namespace DotNetEcuador.API.Validators.Auth;
+
+public class LoginRequestValidator : AbstractValidator<LoginRequest>
+{
+    public LoginRequestValidator()
+    {
+        RuleFor(x => x.Email)
+            .NotEmpty()
+            .WithMessage("El email es requerido")
+            .EmailAddress()
+            .WithMessage("El email debe tener un formato válido")
+            .MaximumLength(255)
+            .WithMessage("El email no puede exceder los 255 caracteres");
+
+        RuleFor(x => x.Password)
+            .NotEmpty()
+            .WithMessage("La contraseña es requerida")
+            .MinimumLength(6)
+            .WithMessage("La contraseña debe tener al menos 6 caracteres");
+    }
+}

--- a/DotNetEcuador.API/Validators/Auth/RegisterRequestValidator.cs
+++ b/DotNetEcuador.API/Validators/Auth/RegisterRequestValidator.cs
@@ -1,0 +1,40 @@
+using DotNetEcuador.API.Models.Auth;
+using FluentValidation;
+
+namespace DotNetEcuador.API.Validators.Auth;
+
+public class RegisterRequestValidator : AbstractValidator<RegisterRequest>
+{
+    public RegisterRequestValidator()
+    {
+        RuleFor(x => x.FullName)
+            .NotEmpty()
+            .WithMessage("El nombre completo es requerido")
+            .MinimumLength(3)
+            .WithMessage("El nombre debe tener al menos 3 caracteres")
+            .MaximumLength(100)
+            .WithMessage("El nombre no puede exceder los 100 caracteres");
+
+        RuleFor(x => x.Email)
+            .NotEmpty()
+            .WithMessage("El email es requerido")
+            .EmailAddress()
+            .WithMessage("El email debe tener un formato válido")
+            .MaximumLength(255)
+            .WithMessage("El email no puede exceder los 255 caracteres");
+
+        RuleFor(x => x.Password)
+            .NotEmpty()
+            .WithMessage("La contraseña es requerida")
+            .MinimumLength(8)
+            .WithMessage("La contraseña debe tener al menos 8 caracteres")
+            .Matches(@"^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).+$")
+            .WithMessage("La contraseña debe contener al menos una mayúscula, una minúscula y un número");
+
+        RuleFor(x => x.ConfirmPassword)
+            .NotEmpty()
+            .WithMessage("La confirmación de contraseña es requerida")
+            .Equal(x => x.Password)
+            .WithMessage("Las contraseñas no coinciden");
+    }
+}

--- a/DotNetEcuador.API/Validators/Common/PagedRequestValidator.cs
+++ b/DotNetEcuador.API/Validators/Common/PagedRequestValidator.cs
@@ -1,0 +1,28 @@
+using DotNetEcuador.API.Models.Common;
+using FluentValidation;
+
+namespace DotNetEcuador.API.Validators.Common;
+
+public class PagedRequestValidator : AbstractValidator<PagedRequest>
+{
+    public PagedRequestValidator()
+    {
+        RuleFor(x => x.Page)
+            .GreaterThan(0)
+            .WithMessage("El número de página debe ser mayor a 0");
+
+        RuleFor(x => x.PageSize)
+            .InclusiveBetween(1, 100)
+            .WithMessage("El tamaño de página debe estar entre 1 y 100");
+
+        RuleFor(x => x.SortOrder)
+            .Must(order => string.IsNullOrEmpty(order) || order.ToLower() == "asc" || order.ToLower() == "desc")
+            .WithMessage("El orden debe ser 'asc' o 'desc'")
+            .When(x => !string.IsNullOrEmpty(x.SortOrder));
+
+        RuleFor(x => x.Search)
+            .MaximumLength(100)
+            .WithMessage("El término de búsqueda no puede exceder los 100 caracteres")
+            .When(x => !string.IsNullOrEmpty(x.Search));
+    }
+}

--- a/DotNetEcuador.API/Validators/VolunteerApplicationValidator.cs
+++ b/DotNetEcuador.API/Validators/VolunteerApplicationValidator.cs
@@ -1,0 +1,80 @@
+using DotNetEcuador.API.Models;
+using FluentValidation;
+
+namespace DotNetEcuador.API.Validators;
+
+public class VolunteerApplicationValidator : AbstractValidator<VolunteerApplication>
+{
+    private readonly HashSet<string> _validAreasOfInterest = new()
+    {
+        "EventOrganization",
+        "ContentCreation",
+        "TechnicalSupport", 
+        "SocialMediaManagement",
+        "Other"
+    };
+
+    public VolunteerApplicationValidator()
+    {
+        RuleFor(x => x.FullName)
+            .NotEmpty()
+            .WithMessage("El nombre completo es requerido")
+            .MinimumLength(3)
+            .WithMessage("El nombre debe tener al menos 3 caracteres")
+            .MaximumLength(100)
+            .WithMessage("El nombre no puede exceder los 100 caracteres");
+
+        RuleFor(x => x.Email)
+            .NotEmpty()
+            .WithMessage("El email es requerido")
+            .EmailAddress()
+            .WithMessage("El email debe tener un formato válido")
+            .MaximumLength(255)
+            .WithMessage("El email no puede exceder los 255 caracteres");
+
+        RuleFor(x => x.PhoneNumber)
+            .MaximumLength(20)
+            .WithMessage("El teléfono no puede exceder los 20 caracteres")
+            .When(x => !string.IsNullOrEmpty(x.PhoneNumber));
+
+        RuleFor(x => x.City)
+            .NotEmpty()
+            .WithMessage("La ciudad es requerida")
+            .MaximumLength(100)
+            .WithMessage("La ciudad no puede exceder los 100 caracteres");
+
+        RuleFor(x => x.AreasOfInterest)
+            .NotEmpty()
+            .WithMessage("Debe seleccionar al menos un área de interés")
+            .Must(areas => areas.All(area => _validAreasOfInterest.Contains(area)))
+            .WithMessage("Una o más áreas de interés seleccionadas no son válidas. Valores válidos: " + 
+                        string.Join(", ", _validAreasOfInterest));
+
+        RuleFor(x => x.OtherAreas)
+            .NotEmpty()
+            .WithMessage("Debe especificar las otras áreas de interés")
+            .When(x => x.AreasOfInterest != null && x.AreasOfInterest.Contains("Other"));
+
+        RuleFor(x => x.AvailableTime)
+            .NotEmpty()
+            .WithMessage("El tiempo disponible es requerido")
+            .MaximumLength(500)
+            .WithMessage("El tiempo disponible no puede exceder los 500 caracteres");
+
+        RuleFor(x => x.SkillsOrKnowledge)
+            .MaximumLength(1000)
+            .WithMessage("Las habilidades no pueden exceder los 1000 caracteres")
+            .When(x => !string.IsNullOrEmpty(x.SkillsOrKnowledge));
+
+        RuleFor(x => x.WhyVolunteer)
+            .NotEmpty()
+            .WithMessage("Debe especificar por qué quiere ser voluntario")
+            .MaximumLength(1000)
+            .WithMessage("La razón no puede exceder los 1000 caracteres");
+
+        RuleFor(x => x.AdditionalComments)
+            .MaximumLength(1000)
+            .WithMessage("Los comentarios adicionales no pueden exceder los 1000 caracteres")
+            .When(x => !string.IsNullOrEmpty(x.AdditionalComments));
+    }
+}

--- a/DotNetEcuador.Tests/DotNetEcuador.Tests.csproj
+++ b/DotNetEcuador.Tests/DotNetEcuador.Tests.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
     <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="FluentValidation" Version="11.8.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.2.1" />
     <PackageReference Include="Moq" Version="4.20.69" />

--- a/DotNetEcuador.Tests/Models/VolunteerApplicationTests.cs
+++ b/DotNetEcuador.Tests/Models/VolunteerApplicationTests.cs
@@ -5,91 +5,6 @@ namespace DotNetEcuador.Tests.Models;
 
 public class VolunteerApplicationTests
 {
-    [Fact]
-    public void ValidateOtherAreasShouldReturnTrueWhenOtherIsNotSelected()
-    {
-        // Arrange
-        var application = new VolunteerApplication
-        {
-            AreasOfInterest = new List<string> { "EventOrganization" },
-            OtherAreas = string.Empty
-        };
-
-        // Act
-        var result = application.ValidateOtherAreas();
-
-        // Assert
-        result.Should().BeTrue();
-    }
-
-    [Fact]
-    public void ValidateOtherAreasShouldReturnTrueWhenOtherIsSelectedAndOtherAreasHasValue()
-    {
-        // Arrange
-        var application = new VolunteerApplication
-        {
-            AreasOfInterest = new List<string> { "Other" },
-            OtherAreas = "Custom area of interest"
-        };
-
-        // Act
-        var result = application.ValidateOtherAreas();
-
-        // Assert
-        result.Should().BeTrue();
-    }
-
-    [Fact]
-    public void ValidateOtherAreasShouldReturnFalseWhenOtherIsSelectedButOtherAreasIsEmpty()
-    {
-        // Arrange
-        var application = new VolunteerApplication
-        {
-            AreasOfInterest = new List<string> { "Other" },
-            OtherAreas = string.Empty
-        };
-
-        // Act
-        var result = application.ValidateOtherAreas();
-
-        // Assert
-        result.Should().BeFalse();
-    }
-
-    [Fact]
-    public void ValidateOtherAreasShouldReturnFalseWhenOtherIsSelectedButOtherAreasIsWhitespace()
-    {
-        // Arrange
-        var application = new VolunteerApplication
-        {
-            AreasOfInterest = new List<string> { "Other" },
-            OtherAreas = "   "
-        };
-
-        // Act
-        var result = application.ValidateOtherAreas();
-
-        // Assert
-        result.Should().BeFalse();
-    }
-
-    [Fact]
-    public void ValidateOtherAreasShouldReturnTrueWhenOtherKeyDoesNotExist()
-    {
-        // Arrange
-        var application = new VolunteerApplication
-        {
-            AreasOfInterest = new List<string> { "EventOrganization", "ContentCreation" },
-            OtherAreas = string.Empty
-        };
-
-        // Act
-        var result = application.ValidateOtherAreas();
-
-        // Assert
-        result.Should().BeTrue();
-    }
-
     [Theory]
     [InlineData("")]
     [InlineData("John Doe")]
@@ -120,5 +35,32 @@ public class VolunteerApplicationTests
 
         // Assert
         application.Email.Should().Be(email);
+    }
+
+    [Fact]
+    public void AreasOfInterestShouldInitializeAsEmptyList()
+    {
+        // Arrange & Act
+        var application = new VolunteerApplication();
+
+        // Assert
+        application.AreasOfInterest.Should().NotBeNull();
+        application.AreasOfInterest.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ShouldAcceptMultipleAreasOfInterest()
+    {
+        // Arrange
+        var areas = new List<string> { "EventOrganization", "TechnicalSupport", "Other" };
+
+        // Act
+        var application = new VolunteerApplication
+        {
+            AreasOfInterest = areas
+        };
+
+        // Assert
+        application.AreasOfInterest.Should().BeEquivalentTo(areas);
     }
 }

--- a/DotNetEcuador.Tests/Services/VolunteerApplicationServiceTests.cs
+++ b/DotNetEcuador.Tests/Services/VolunteerApplicationServiceTests.cs
@@ -1,6 +1,8 @@
 using DotNetEcuador.API.Models;
+using DotNetEcuador.API.Models.Common;
 using DotNetEcuador.API.Infraestructure.Services;
 using DotNetEcuador.API.Infraestructure.Repositories;
+using DotNetEcuador.API.Exceptions;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
@@ -48,70 +50,173 @@ public class VolunteerApplicationServiceTests
             AdditionalComments = "Available immediately"
         };
 
-        // Act
-        await _service.CreateAsync(application).ConfigureAwait(false);
-
-        // Assert
-        _mockRepository.Verify(
-            repo => repo.CreateAsync(application),
-            Times.Once);
-    }
-
-    [Theory]
-    [InlineData("EventOrganization", true)]
-    [InlineData("ContentCreation", true)]
-    [InlineData("TechnicalSupport", true)]
-    [InlineData("SocialMediaManagement", true)]
-    [InlineData("Other", true)]
-    [InlineData("InvalidArea", false)]
-    public void AreValidAreasOfInterestShouldValidateAreaNamesCorrectly(string areaName, bool expectedValid)
-    {
-        // Arrange
-        var areasOfInterest = new List<string> { areaName };
+        // Mock that no existing application is found (email is unique)
+        _mockRepository
+            .Setup(repo => repo.FindAsync(It.IsAny<System.Linq.Expressions.Expression<System.Func<VolunteerApplication, bool>>>()))
+            .ReturnsAsync((VolunteerApplication?)null);
 
         // Act
-        var result = _service.AreValidAreasOfInterest(areasOfInterest);
+        await _service.CreateAsync(application);
 
         // Assert
-        result.Should().Be(expectedValid);
+        _mockRepository.Verify(repo => repo.FindAsync(It.IsAny<System.Linq.Expressions.Expression<System.Func<VolunteerApplication, bool>>>()), Times.Once);
+        _mockRepository.Verify(repo => repo.CreateAsync(application), Times.Once);
     }
 
     [Fact]
-    public void AreValidAreasOfInterestShouldReturnTrueWhenAllAreasAreValid()
+    public async Task GetAllAsyncShouldCallRepositoryGetPagedAsync()
     {
         // Arrange
-        var areasOfInterest = new List<string> { "EventOrganization", "TechnicalSupport" };
+        var request = new PagedRequest { Page = 1, PageSize = 10 };
+        var expectedResponse = new PagedResponse<VolunteerApplication>();
+
+        _mockRepository
+            .Setup(repo => repo.GetPagedAsync(request))
+            .ReturnsAsync(expectedResponse);
 
         // Act
-        var result = _service.AreValidAreasOfInterest(areasOfInterest);
+        var result = await _service.GetAllAsync(request);
 
         // Assert
-        result.Should().BeTrue();
+        result.Should().Be(expectedResponse);
+        _mockRepository.Verify(repo => repo.GetPagedAsync(request), Times.Once);
     }
 
     [Fact]
-    public void AreValidAreasOfInterestShouldReturnFalseWhenAnyAreaIsInvalid()
+    public async Task SearchAsyncShouldReturnGetAllAsyncWhenSearchTermIsEmpty()
     {
         // Arrange
-        var areasOfInterest = new List<string> { "EventOrganization", "InvalidArea" };
+        var request = new PagedRequest { Page = 1, PageSize = 10 };
+        var expectedResponse = new PagedResponse<VolunteerApplication>();
+
+        _mockRepository
+            .Setup(repo => repo.GetPagedAsync(request))
+            .ReturnsAsync(expectedResponse);
 
         // Act
-        var result = _service.AreValidAreasOfInterest(areasOfInterest);
+        var result = await _service.SearchAsync(request, string.Empty);
 
         // Assert
-        result.Should().BeFalse();
+        result.Should().Be(expectedResponse);
+        _mockRepository.Verify(repo => repo.GetPagedAsync(request), Times.Once);
     }
 
     [Fact]
-    public void AreValidAreasOfInterestShouldReturnFalseWhenListIsEmpty()
+    public async Task GetByEmailAsyncShouldReturnApplicationWhenEmailExists()
     {
         // Arrange
-        var areasOfInterest = new List<string>();
+        var email = "test@example.com";
+        var expectedApplication = new VolunteerApplication
+        {
+            FullName = "John Doe",
+            Email = email,
+            City = "Quito"
+        };
+
+        _mockRepository
+            .Setup(repo => repo.FindAsync(It.IsAny<System.Linq.Expressions.Expression<System.Func<VolunteerApplication, bool>>>()))
+            .ReturnsAsync(expectedApplication);
 
         // Act
-        var result = _service.AreValidAreasOfInterest(areasOfInterest);
+        var result = await _service.GetByEmailAsync(email);
 
         // Assert
-        result.Should().BeFalse();
+        result.Should().Be(expectedApplication);
+        result!.Email.Should().Be(email);
+        _mockRepository.Verify(repo => repo.FindAsync(It.IsAny<System.Linq.Expressions.Expression<System.Func<VolunteerApplication, bool>>>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetByEmailAsyncShouldReturnNullWhenEmailDoesNotExist()
+    {
+        // Arrange
+        var email = "nonexistent@example.com";
+
+        _mockRepository
+            .Setup(repo => repo.FindAsync(It.IsAny<System.Linq.Expressions.Expression<System.Func<VolunteerApplication, bool>>>()))
+            .ReturnsAsync((VolunteerApplication?)null);
+
+        // Act
+        var result = await _service.GetByEmailAsync(email);
+
+        // Assert
+        result.Should().BeNull();
+        _mockRepository.Verify(repo => repo.FindAsync(It.IsAny<System.Linq.Expressions.Expression<System.Func<VolunteerApplication, bool>>>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetByEmailAsyncShouldReturnNullWhenEmailIsEmpty()
+    {
+        // Act
+        var result = await _service.GetByEmailAsync(string.Empty);
+
+        // Assert
+        result.Should().BeNull();
+        _mockRepository.Verify(repo => repo.FindAsync(It.IsAny<System.Linq.Expressions.Expression<System.Func<VolunteerApplication, bool>>>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateAsyncShouldThrowDuplicateEmailExceptionWhenEmailAlreadyExists()
+    {
+        // Arrange
+        var email = "duplicate@example.com";
+        var existingApplication = new VolunteerApplication
+        {
+            FullName = "Existing User",
+            Email = email,
+            City = "Guayaquil"
+        };
+
+        var newApplication = new VolunteerApplication
+        {
+            FullName = "New User",
+            Email = email,
+            City = "Quito"
+        };
+
+        _mockRepository
+            .Setup(repo => repo.FindAsync(It.IsAny<System.Linq.Expressions.Expression<System.Func<VolunteerApplication, bool>>>()))
+            .ReturnsAsync(existingApplication);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<DuplicateEmailException>(() => _service.CreateAsync(newApplication));
+        
+        exception.Email.Should().Be(email);
+        exception.Message.Should().Contain(email);
+        _mockRepository.Verify(repo => repo.CreateAsync(It.IsAny<VolunteerApplication>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateAsyncShouldSucceedWhenEmailIsUnique()
+    {
+        // Arrange
+        var application = new VolunteerApplication
+        {
+            FullName = "John Doe",
+            Email = "unique@example.com",
+            PhoneNumber = "123456789",
+            City = "Quito",
+            HasVolunteeringExperience = true,
+            AreasOfInterest = new List<string> { "EventOrganization" },
+            AvailableTime = "Weekends",
+            SkillsOrKnowledge = "Programming, Marketing",
+            WhyVolunteer = "Want to contribute to the community",
+            AdditionalComments = "Available immediately"
+        };
+
+        _mockRepository
+            .Setup(repo => repo.FindAsync(It.IsAny<System.Linq.Expressions.Expression<System.Func<VolunteerApplication, bool>>>()))
+            .ReturnsAsync((VolunteerApplication?)null);
+
+        _mockRepository
+            .Setup(repo => repo.CreateAsync(It.IsAny<VolunteerApplication>()))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _service.CreateAsync(application);
+
+        // Assert
+        _mockRepository.Verify(repo => repo.FindAsync(It.IsAny<System.Linq.Expressions.Expression<System.Func<VolunteerApplication, bool>>>()), Times.Once);
+        _mockRepository.Verify(repo => repo.CreateAsync(application), Times.Once);
     }
 }

--- a/DotNetEcuador.Tests/Validators/Auth/RegisterRequestValidatorTests.cs
+++ b/DotNetEcuador.Tests/Validators/Auth/RegisterRequestValidatorTests.cs
@@ -1,0 +1,109 @@
+using DotNetEcuador.API.Models.Auth;
+using DotNetEcuador.API.Validators.Auth;
+using FluentAssertions;
+using FluentValidation.TestHelper;
+
+namespace DotNetEcuador.Tests.Validators.Auth;
+
+public class RegisterRequestValidatorTests
+{
+    private readonly RegisterRequestValidator _validator;
+
+    public RegisterRequestValidatorTests()
+    {
+        _validator = new RegisterRequestValidator();
+    }
+
+    [Fact]
+    public void ShouldHaveErrorWhenFullNameIsEmpty()
+    {
+        // Arrange
+        var model = new RegisterRequest { FullName = string.Empty };
+
+        // Act & Assert
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.FullName)
+            .WithErrorMessage("El nombre completo es requerido");
+    }
+
+    [Fact]
+    public void ShouldHaveErrorWhenFullNameIsTooShort()
+    {
+        // Arrange
+        var model = new RegisterRequest { FullName = "Ab" };
+
+        // Act & Assert
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.FullName)
+            .WithErrorMessage("El nombre debe tener al menos 3 caracteres");
+    }
+
+    [Fact]
+    public void ShouldHaveErrorWhenEmailIsInvalid()
+    {
+        // Arrange
+        var model = new RegisterRequest { Email = "invalid-email" };
+
+        // Act & Assert
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.Email)
+            .WithErrorMessage("El email debe tener un formato válido");
+    }
+
+    [Fact]
+    public void ShouldHaveErrorWhenPasswordIsTooShort()
+    {
+        // Arrange
+        var model = new RegisterRequest { Password = "1234567" };
+
+        // Act & Assert
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.Password)
+            .WithErrorMessage("La contraseña debe tener al menos 8 caracteres");
+    }
+
+    [Fact]
+    public void ShouldHaveErrorWhenPasswordDoesNotMeetComplexity()
+    {
+        // Arrange
+        var model = new RegisterRequest { Password = "password123" };
+
+        // Act & Assert
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.Password)
+            .WithErrorMessage("La contraseña debe contener al menos una mayúscula, una minúscula y un número");
+    }
+
+    [Fact]
+    public void ShouldHaveErrorWhenPasswordsDoNotMatch()
+    {
+        // Arrange
+        var model = new RegisterRequest 
+        { 
+            Password = "Password123",
+            ConfirmPassword = "DifferentPassword123"
+        };
+
+        // Act & Assert
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.ConfirmPassword)
+            .WithErrorMessage("Las contraseñas no coinciden");
+    }
+
+    [Fact]
+    public void ShouldNotHaveErrorWhenValidModel()
+    {
+        // Arrange
+        var model = new RegisterRequest 
+        { 
+            FullName = "Juan Pérez",
+            Email = "juan@ejemplo.com",
+            Password = "Password123",
+            ConfirmPassword = "Password123"
+        };
+
+        // Act & Assert
+        var result = _validator.TestValidate(model);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+}

--- a/DotNetEcuador.Tests/Validators/VolunteerApplicationValidatorTests.cs
+++ b/DotNetEcuador.Tests/Validators/VolunteerApplicationValidatorTests.cs
@@ -1,0 +1,146 @@
+using DotNetEcuador.API.Models;
+using DotNetEcuador.API.Validators;
+using FluentAssertions;
+using FluentValidation.TestHelper;
+
+namespace DotNetEcuador.Tests.Validators;
+
+public class VolunteerApplicationValidatorTests
+{
+    private readonly VolunteerApplicationValidator _validator;
+
+    public VolunteerApplicationValidatorTests()
+    {
+        _validator = new VolunteerApplicationValidator();
+    }
+
+    [Fact]
+    public void ShouldHaveErrorWhenFullNameIsEmpty()
+    {
+        // Arrange
+        var model = new VolunteerApplication { FullName = string.Empty };
+
+        // Act & Assert
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.FullName)
+            .WithErrorMessage("El nombre completo es requerido");
+    }
+
+    [Fact]
+    public void ShouldHaveErrorWhenFullNameIsTooShort()
+    {
+        // Arrange
+        var model = new VolunteerApplication { FullName = "Ab" };
+
+        // Act & Assert
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.FullName)
+            .WithErrorMessage("El nombre debe tener al menos 3 caracteres");
+    }
+
+    [Fact]
+    public void ShouldHaveErrorWhenEmailIsEmpty()
+    {
+        // Arrange
+        var model = new VolunteerApplication { Email = string.Empty };
+
+        // Act & Assert
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.Email)
+            .WithErrorMessage("El email es requerido");
+    }
+
+    [Fact]
+    public void ShouldHaveErrorWhenEmailIsInvalid()
+    {
+        // Arrange
+        var model = new VolunteerApplication { Email = "invalid-email" };
+
+        // Act & Assert
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.Email)
+            .WithErrorMessage("El email debe tener un formato válido");
+    }
+
+    [Fact]
+    public void ShouldHaveErrorWhenAreasOfInterestIsEmpty()
+    {
+        // Arrange
+        var model = new VolunteerApplication { AreasOfInterest = new List<string>() };
+
+        // Act & Assert
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.AreasOfInterest)
+            .WithErrorMessage("Debe seleccionar al menos un área de interés");
+    }
+
+    [Fact]
+    public void ShouldHaveErrorWhenAreasOfInterestContainsInvalidValues()
+    {
+        // Arrange
+        var model = new VolunteerApplication 
+        { 
+            AreasOfInterest = new List<string> { "InvalidArea" } 
+        };
+
+        // Act & Assert
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.AreasOfInterest)
+            .WithErrorMessage("Una o más áreas de interés seleccionadas no son válidas. Valores válidos: EventOrganization, ContentCreation, TechnicalSupport, SocialMediaManagement, Other");
+    }
+
+    [Fact]
+    public void ShouldHaveErrorWhenOtherAreasIsEmptyButOtherIsSelected()
+    {
+        // Arrange
+        var model = new VolunteerApplication 
+        { 
+            AreasOfInterest = new List<string> { "Other" },
+            OtherAreas = string.Empty
+        };
+
+        // Act & Assert
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.OtherAreas)
+            .WithErrorMessage("Debe especificar las otras áreas de interés");
+    }
+
+    [Fact]
+    public void ShouldNotHaveErrorWhenOtherAreasIsFilledAndOtherIsSelected()
+    {
+        // Arrange
+        var model = new VolunteerApplication 
+        { 
+            FullName = "Juan Pérez",
+            Email = "juan@ejemplo.com",
+            City = "Quito",
+            AreasOfInterest = new List<string> { "Other" },
+            OtherAreas = "Mentoring",
+            AvailableTime = "Weekends",
+            WhyVolunteer = "Want to help"
+        };
+
+        // Act & Assert
+        var result = _validator.TestValidate(model);
+        result.ShouldNotHaveValidationErrorFor(x => x.OtherAreas);
+    }
+
+    [Fact]
+    public void ShouldNotHaveErrorWhenValidModel()
+    {
+        // Arrange
+        var model = new VolunteerApplication 
+        { 
+            FullName = "Juan Pérez González",
+            Email = "juan@ejemplo.com",
+            City = "Quito",
+            AreasOfInterest = new List<string> { "EventOrganization", "TechnicalSupport" },
+            AvailableTime = "Weekends and evenings",
+            WhyVolunteer = "I want to contribute to the community"
+        };
+
+        // Act & Assert
+        var result = _validator.TestValidate(model);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+}


### PR DESCRIPTION
# Validaciones con fluent validation y standarización de respuesta

Validación de Emails Duplicados en Aplicaciones de Voluntarios

  Problema: El endpoint /api/v1/volunteer-application/apply
  permitía registrar múltiples voluntarios con el mismo email.

  Solución: Implementé validación completa de emails únicos con
  manejo de errores estándar.

  Cambios Principales:

  - GetByEmailAsync() - Nuevo método para buscar voluntarios por
  email
  - DuplicateEmailException - Excepción específica para emails
  duplicados
  - Validación en CreateAsync() - Verifica emails únicos antes de
  insertar
  - GlobalExceptionMiddleware - Maneja errores con HTTP 409
  (Conflict)

  Testing

  - Tests para validación de duplicados
  - Tests para búsqueda por email
  - Actualización de tests existentes para nuevos formatos de
  respuesta