### PR TITLE
fix:  removed asistente.Nombre of callback_data

### DIFF
--- a/DotNetEcuador.API/Infraestructure/Services/Telegram/TelegramBotService.cs
+++ b/DotNetEcuador.API/Infraestructure/Services/Telegram/TelegramBotService.cs
@@ -39,8 +39,8 @@ public class TelegramBotService : ITelegramBotService
         {
             new[]
             {
-                InlineKeyboardButton.WithCallbackData("✅ Aprobar", $"action:aprobar:{registro.Id}:{registro.IdCorto}:{asistente.Nombre}"),
-                InlineKeyboardButton.WithCallbackData("❌ Rechazar", $"action:rechazar:{registro.Id}:{registro.IdCorto}:{asistente.Nombre}")
+                InlineKeyboardButton.WithCallbackData("✅ Aprobar", $"action:aprobar:{registro.Id}:{registro.IdCorto}"),
+                InlineKeyboardButton.WithCallbackData("❌ Rechazar", $"action:rechazar:{registro.Id}:{registro.IdCorto}")
             }
         });
 

--- a/DotNetEcuador.API/Infraestructure/Services/Telegram/TelegramUpdateHandler.cs
+++ b/DotNetEcuador.API/Infraestructure/Services/Telegram/TelegramUpdateHandler.cs
@@ -54,16 +54,15 @@ public class TelegramUpdateHandler
 
         var data = callback.Data ?? string.Empty;
 
-        // action:aprobar:{registroId}:{idCorto}:{nombre}
+        // action:aprobar:{registroId}:{idCorto}
         if (data.StartsWith("action:"))
         {
-            var partes = data.Split(':', 5);
-            if (partes.Length < 5) return;
+            var partes = data.Split(':', 4);
+            if (partes.Length < 4) return;
 
             var accion = partes[1] == "aprobar" ? TelegramAccion.Aprobar : TelegramAccion.Rechazar;
             var registroId = partes[2];
             var idCorto = partes[3];
-            var nombre = partes[4];
             var accionTexto = accion == TelegramAccion.Aprobar ? "aprobar" : "rechazar";
 
             Estado[chatId] = new PendingAction
@@ -71,7 +70,7 @@ public class TelegramUpdateHandler
                 Accion = accion,
                 RegistroId = registroId,
                 IdCorto = idCorto,
-                NombreAsistente = nombre
+                NombreAsistente = string.Empty
             };
 
             var teclado = new InlineKeyboardMarkup(new[]
@@ -85,7 +84,7 @@ public class TelegramUpdateHandler
 
             await _bot.SendMessage(
                 chatId: chatId,
-                text: $"¿Estás seguro de *{accionTexto}* el registro `{idCorto}` de *{nombre}*?",
+                text: $"¿Estás seguro de *{accionTexto}* el registro `{idCorto}`?",
                 parseMode: ParseMode.Markdown,
                 replyMarkup: teclado).ConfigureAwait(false);
         }


### PR DESCRIPTION
- TelegramBotService.cs — removido asistente.Nombre del callback_data (era la causa del error 400)
- TelegramUpdateHandler.cs — actualizado para parsear 4 partes en vez de 5, y el mensaje de confirmación ya no incluye el nombre