### PR TITLE
feat: promo code validation

### DIFF
--- a/DotNetEcuador.API/Common/Constants.cs
+++ b/DotNetEcuador.API/Common/Constants.cs
@@ -20,5 +20,6 @@ public static class Constants
         public const string REGISTROS = "inscripciones_eventos";
         public const string EMAIL_LOG = "emailLog";
         public const string DATOS_PAGO = "datos_pago";
+        public const string PROMO_CODES = "promo_codes";
     }
 }

--- a/DotNetEcuador.API/Configuration/MongoDbConfiguration.cs
+++ b/DotNetEcuador.API/Configuration/MongoDbConfiguration.cs
@@ -68,6 +68,7 @@ public static class MongoDbConfiguration
             services.AddMongoRepository<Registro>(Constants.MongoCollections.REGISTROS);
             services.AddMongoRepository<EmailLog>(Constants.MongoCollections.EMAIL_LOG);
             services.AddMongoRepository<DatosPago>(Constants.MongoCollections.DATOS_PAGO);
+            services.AddMongoRepository<PromoCode>(Constants.MongoCollections.PROMO_CODES);
         }
         catch (Exception ex)
         {

--- a/DotNetEcuador.API/Configuration/ServicesConfiguration.cs
+++ b/DotNetEcuador.API/Configuration/ServicesConfiguration.cs
@@ -48,5 +48,6 @@ public static class ServicesConfiguration
         services.AddScoped<IQrService, QrService>();
         services.AddScoped<IEmailEventoService, EmailEventoService>();
         services.AddScoped<IExportService, ExportService>();
+        services.AddScoped<IPromoCodeService, PromoCodeService>();
     }
 }

--- a/DotNetEcuador.API/Controllers/V1/PromoCodesController.cs
+++ b/DotNetEcuador.API/Controllers/V1/PromoCodesController.cs
@@ -1,0 +1,40 @@
+using Asp.Versioning;
+using DotNetEcuador.API.Controllers;
+using DotNetEcuador.API.Infraestructure.Services.Eventos;
+using DotNetEcuador.API.Models.Eventos.DTOs;
+using DotNetEcuador.API.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DotNetEcuador.API.Controllers.V1;
+
+[Route("api/v{version:apiVersion}/promo-codes")]
+[ApiVersion("1.0")]
+public class PromoCodesController : BaseApiController
+{
+    private readonly IPromoCodeService _promoCodeService;
+
+    public PromoCodesController(
+        IPromoCodeService promoCodeService,
+        IMessageService messageService,
+        ILogger<PromoCodesController> logger) : base(messageService, logger)
+    {
+        _promoCodeService = promoCodeService;
+    }
+
+    /// <summary>
+    /// Validates a promo code. Does not increment usage — only validates eligibility.
+    /// </summary>
+    [HttpPost("validate")]
+    [ProducesResponseType(200)]
+    [ProducesResponseType(400)]
+    [ProducesResponseType(422)]
+    public async Task<IActionResult> Validate([FromBody] PromoCodeValidateRequestDto request)
+    {
+        var result = await _promoCodeService.ValidateAsync(request.Code).ConfigureAwait(false);
+
+        if (!result.Valid)
+            return BusinessError("promo-invalido", result.Message, 422);
+
+        return SuccessResponse(result, result.Message);
+    }
+}

--- a/DotNetEcuador.API/Infraestructure/Services/Eventos/IPromoCodeService.cs
+++ b/DotNetEcuador.API/Infraestructure/Services/Eventos/IPromoCodeService.cs
@@ -1,0 +1,8 @@
+using DotNetEcuador.API.Models.Eventos.DTOs;
+
+namespace DotNetEcuador.API.Infraestructure.Services.Eventos;
+
+public interface IPromoCodeService
+{
+    Task<PromoCodeValidateResponseDto> ValidateAsync(string code);
+}

--- a/DotNetEcuador.API/Infraestructure/Services/Eventos/PromoCodeService.cs
+++ b/DotNetEcuador.API/Infraestructure/Services/Eventos/PromoCodeService.cs
@@ -1,0 +1,48 @@
+using DotNetEcuador.API.Infraestructure.Repositories;
+using DotNetEcuador.API.Models.Eventos;
+using DotNetEcuador.API.Models.Eventos.DTOs;
+
+namespace DotNetEcuador.API.Infraestructure.Services.Eventos;
+
+public class PromoCodeService : IPromoCodeService
+{
+    private readonly IRepository<PromoCode> _promoCodeRepository;
+    private readonly ILogger<PromoCodeService> _logger;
+
+    public PromoCodeService(
+        IRepository<PromoCode> promoCodeRepository,
+        ILogger<PromoCodeService> logger)
+    {
+        _promoCodeRepository = promoCodeRepository;
+        _logger = logger;
+    }
+
+    public async Task<PromoCodeValidateResponseDto> ValidateAsync(string code)
+    {
+        var upperCode = code.ToUpperInvariant();
+
+        var promoCode = await _promoCodeRepository.FindAsync(p =>
+            p.Code == upperCode &&
+            p.IsActive).ConfigureAwait(false);
+
+        if (promoCode is null)
+            return Invalid();
+
+        if (promoCode.MaxUses.HasValue && promoCode.CurrentUses >= promoCode.MaxUses.Value)
+            return Invalid();
+
+        if (promoCode.ExpiresAt.HasValue && promoCode.ExpiresAt.Value < DateTime.UtcNow)
+            return Invalid();
+
+        _logger.LogInformation("Promo code {Code} validated successfully", upperCode);
+
+        return new PromoCodeValidateResponseDto
+        {
+            Valid = true,
+            Message = "¡Código aplicado! Tu acceso está confirmado."
+        };
+    }
+
+    private static PromoCodeValidateResponseDto Invalid() =>
+        new() { Valid = false, Message = "Código no válido o expirado." };
+}

--- a/DotNetEcuador.API/Models/Eventos/DTOs/PromoCodeDtos.cs
+++ b/DotNetEcuador.API/Models/Eventos/DTOs/PromoCodeDtos.cs
@@ -1,0 +1,12 @@
+namespace DotNetEcuador.API.Models.Eventos.DTOs;
+
+public class PromoCodeValidateRequestDto
+{
+    public string Code { get; set; } = string.Empty;
+}
+
+public class PromoCodeValidateResponseDto
+{
+    public bool Valid { get; set; }
+    public string Message { get; set; } = string.Empty;
+}

--- a/DotNetEcuador.API/Models/Eventos/PromoCode.cs
+++ b/DotNetEcuador.API/Models/Eventos/PromoCode.cs
@@ -1,0 +1,32 @@
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace DotNetEcuador.API.Models.Eventos;
+
+public class PromoCode
+{
+    [BsonId]
+    [BsonRepresentation(BsonType.ObjectId)]
+    public string Id { get; set; } = string.Empty;
+
+    [BsonElement("code")]
+    public string Code { get; set; } = string.Empty;
+
+    [BsonElement("description")]
+    public string Description { get; set; } = string.Empty;
+
+    [BsonElement("isActive")]
+    public bool IsActive { get; set; } = true;
+
+    [BsonElement("maxUses")]
+    public int? MaxUses { get; set; }
+
+    [BsonElement("currentUses")]
+    public int CurrentUses { get; set; } = 0;
+
+    [BsonElement("expiresAt")]
+    public DateTime? ExpiresAt { get; set; }
+
+    [BsonElement("createdAt")]
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/DotNetEcuador.API/Validators/Eventos/PromoCodeValidateRequestValidator.cs
+++ b/DotNetEcuador.API/Validators/Eventos/PromoCodeValidateRequestValidator.cs
@@ -1,0 +1,15 @@
+using DotNetEcuador.API.Models.Eventos.DTOs;
+using FluentValidation;
+
+namespace DotNetEcuador.API.Validators.Eventos;
+
+public class PromoCodeValidateRequestValidator : AbstractValidator<PromoCodeValidateRequestDto>
+{
+    public PromoCodeValidateRequestValidator()
+    {
+        RuleFor(x => x.Code)
+            .NotEmpty().WithMessage("El código es requerido.")
+            .Length(6).WithMessage("El código debe tener exactamente 6 caracteres.")
+            .Matches("^[A-Za-z0-9]{6}$").WithMessage("El código solo puede contener letras y números.");
+    }
+}

--- a/DotNetEcuador.Tests/Controllers/PromoCodesControllerTests.cs
+++ b/DotNetEcuador.Tests/Controllers/PromoCodesControllerTests.cs
@@ -1,0 +1,147 @@
+using DotNetEcuador.API.Controllers.V1;
+using DotNetEcuador.API.Infraestructure.Services.Eventos;
+using DotNetEcuador.API.Models.Common;
+using DotNetEcuador.API.Models.Eventos.DTOs;
+using DotNetEcuador.API.Services;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace DotNetEcuador.Tests.Controllers;
+
+public class PromoCodesControllerTests
+{
+    private readonly Mock<IPromoCodeService> _mockService;
+    private readonly Mock<IMessageService> _mockMessageService;
+    private readonly Mock<ILogger<PromoCodesController>> _mockLogger;
+    private readonly PromoCodesController _controller;
+
+    public PromoCodesControllerTests()
+    {
+        _mockService = new Mock<IPromoCodeService>();
+        _mockMessageService = new Mock<IMessageService>();
+        _mockLogger = new Mock<ILogger<PromoCodesController>>();
+
+        _controller = new PromoCodesController(
+            _mockService.Object,
+            _mockMessageService.Object,
+            _mockLogger.Object);
+
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext()
+        };
+    }
+
+    private static PromoCodeValidateRequestDto Request(string code) => new() { Code = code };
+
+    private void SetupService(bool valid, string message = "") =>
+        _mockService
+            .Setup(s => s.ValidateAsync(It.IsAny<string>()))
+            .ReturnsAsync(new PromoCodeValidateResponseDto { Valid = valid, Message = message });
+
+    // Código válido
+
+    [Fact]
+    public async Task Validate_CuandoCodigoValido_RetornaOkConDatos()
+    {
+        var responseDto = new PromoCodeValidateResponseDto
+        {
+            Valid = true,
+            Message = "¡Código aplicado! Tu acceso está confirmado."
+        };
+        _mockService.Setup(s => s.ValidateAsync("TEST01")).ReturnsAsync(responseDto);
+
+        var result = await _controller.Validate(Request("TEST01"));
+
+        var okResult = result.Should().BeOfType<OkObjectResult>().Subject;
+        var apiResponse = okResult.Value.Should().BeOfType<ApiResponse<PromoCodeValidateResponseDto>>().Subject;
+        apiResponse.Success.Should().BeTrue();
+        apiResponse.Data!.Valid.Should().BeTrue();
+        apiResponse.Message.Should().Be("¡Código aplicado! Tu acceso está confirmado.");
+    }
+
+    [Fact]
+    public async Task Validate_CuandoCodigoValido_RetornaStatus200()
+    {
+        SetupService(valid: true, message: "¡Código aplicado! Tu acceso está confirmado.");
+
+        var result = await _controller.Validate(Request("TEST01"));
+
+        result.Should().BeOfType<OkObjectResult>()
+            .Which.StatusCode.Should().Be(200);
+    }
+
+    // Código inválido
+
+    [Fact]
+    public async Task Validate_CuandoCodigoInvalido_RetornaStatus422()
+    {
+        SetupService(valid: false, message: "Código no válido o expirado.");
+
+        var result = await _controller.Validate(Request("BADCOD"));
+
+        result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(422);
+    }
+
+    [Fact]
+    public async Task Validate_CuandoCodigoInvalido_CuerpoEsApiError()
+    {
+        SetupService(valid: false, message: "Código no válido o expirado.");
+
+        var result = await _controller.Validate(Request("BADCOD"));
+
+        var objectResult = result.Should().BeOfType<ObjectResult>().Subject;
+        objectResult.Value.Should().BeOfType<ApiError>();
+    }
+
+    [Fact]
+    public async Task Validate_CuandoCodigoInvalido_ApiErrorContieneMensaje()
+    {
+        SetupService(valid: false, message: "Código no válido o expirado.");
+
+        var result = await _controller.Validate(Request("BADCOD"));
+
+        var objectResult = (ObjectResult)result;
+        var apiError = (ApiError)objectResult.Value!;
+        apiError.Detail.Should().Be("Código no válido o expirado.");
+    }
+
+    // Delegación al servicio
+
+    [Fact]
+    public async Task Validate_PasaElCodigoExactoAlServicio()
+    {
+        SetupService(valid: true);
+
+        await _controller.Validate(Request("ABCD12"));
+
+        _mockService.Verify(s => s.ValidateAsync("ABCD12"), Times.Once);
+    }
+
+    [Fact]
+    public async Task Validate_LlamaAlServicioExactamenteUnaVez()
+    {
+        SetupService(valid: true);
+
+        await _controller.Validate(Request("TEST01"));
+
+        _mockService.Verify(s => s.ValidateAsync(It.IsAny<string>()), Times.Once);
+    }
+
+    // Propagación de excepciones
+
+    [Fact]
+    public async Task Validate_CuandoServicioLanzaExcepcion_PropagaExcepcion()
+    {
+        _mockService
+            .Setup(s => s.ValidateAsync(It.IsAny<string>()))
+            .ThrowsAsync(new Exception("Error de base de datos"));
+
+        await Assert.ThrowsAsync<Exception>(() =>
+            _controller.Validate(Request("TEST01")));
+    }
+}

--- a/DotNetEcuador.Tests/Services/Eventos/PromoCodeServiceTests.cs
+++ b/DotNetEcuador.Tests/Services/Eventos/PromoCodeServiceTests.cs
@@ -1,0 +1,166 @@
+using DotNetEcuador.API.Infraestructure.Repositories;
+using DotNetEcuador.API.Infraestructure.Services.Eventos;
+using DotNetEcuador.API.Models.Eventos;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace DotNetEcuador.Tests.Services.Eventos;
+
+public class PromoCodeServiceTests
+{
+    private readonly Mock<IRepository<PromoCode>> _mockRepo;
+    private readonly Mock<ILogger<PromoCodeService>> _mockLogger;
+    private readonly IPromoCodeService _service;
+
+    public PromoCodeServiceTests()
+    {
+        _mockRepo = new Mock<IRepository<PromoCode>>();
+        _mockLogger = new Mock<ILogger<PromoCodeService>>();
+        _service = new PromoCodeService(_mockRepo.Object, _mockLogger.Object);
+    }
+
+    private static PromoCode CodigoActivo(
+        string code = "TEST01",
+        int? maxUses = null,
+        int currentUses = 0,
+        DateTime? expiresAt = null) => new()
+    {
+        Id = "507f1f77bcf86cd799439011",
+        Code = code,
+        Description = "Código de prueba",
+        IsActive = true,
+        MaxUses = maxUses,
+        CurrentUses = currentUses,
+        ExpiresAt = expiresAt,
+        CreatedAt = DateTime.UtcNow
+    };
+
+    private void SetupRepo(PromoCode? returning) =>
+        _mockRepo
+            .Setup(r => r.FindAsync(It.IsAny<System.Linq.Expressions.Expression<Func<PromoCode, bool>>>()))
+            .ReturnsAsync(returning);
+
+    // Casos inválidos
+
+    [Fact]
+    public async Task ValidateAsync_CuandoCodigoNoExiste_RetornaInvalido()
+    {
+        SetupRepo(null);
+
+        var result = await _service.ValidateAsync("NOEXST");
+
+        result.Valid.Should().BeFalse();
+        result.Message.Should().Be("Código no válido o expirado.");
+    }
+
+    [Fact]
+    public async Task ValidateAsync_CuandoMaxUsesExactamenteAlcanzado_RetornaInvalido()
+    {
+        SetupRepo(CodigoActivo(maxUses: 10, currentUses: 10));
+
+        var result = await _service.ValidateAsync("TEST01");
+
+        result.Valid.Should().BeFalse();
+        result.Message.Should().Be("Código no válido o expirado.");
+    }
+
+    [Fact]
+    public async Task ValidateAsync_CuandoCurrentUsesSuperaMaxUses_RetornaInvalido()
+    {
+        SetupRepo(CodigoActivo(maxUses: 5, currentUses: 10));
+
+        var result = await _service.ValidateAsync("TEST01");
+
+        result.Valid.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ValidateAsync_CuandoCodigoVencidoAyer_RetornaInvalido()
+    {
+        SetupRepo(CodigoActivo(expiresAt: DateTime.UtcNow.AddDays(-1)));
+
+        var result = await _service.ValidateAsync("TEST01");
+
+        result.Valid.Should().BeFalse();
+        result.Message.Should().Be("Código no válido o expirado.");
+    }
+
+    [Fact]
+    public async Task ValidateAsync_CuandoCodigoVencidoHaceUnSegundo_RetornaInvalido()
+    {
+        SetupRepo(CodigoActivo(expiresAt: DateTime.UtcNow.AddSeconds(-1)));
+
+        var result = await _service.ValidateAsync("TEST01");
+
+        result.Valid.Should().BeFalse();
+    }
+
+    // Casos válidos
+
+    [Fact]
+    public async Task ValidateAsync_CuandoCodigoActivoSinLimites_RetornaValido()
+    {
+        SetupRepo(CodigoActivo());
+
+        var result = await _service.ValidateAsync("TEST01");
+
+        result.Valid.Should().BeTrue();
+        result.Message.Should().Be("¡Código aplicado! Tu acceso está confirmado.");
+    }
+
+    [Fact]
+    public async Task ValidateAsync_CuandoMaxUsesNoAlcanzado_RetornaValido()
+    {
+        SetupRepo(CodigoActivo(maxUses: 100, currentUses: 99));
+
+        var result = await _service.ValidateAsync("TEST01");
+
+        result.Valid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ValidateAsync_CuandoExpiracionFutura_RetornaValido()
+    {
+        SetupRepo(CodigoActivo(expiresAt: DateTime.UtcNow.AddDays(30)));
+
+        var result = await _service.ValidateAsync("TEST01");
+
+        result.Valid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ValidateAsync_CuandoMaxUsesNuloYExpiracionNula_RetornaValido()
+    {
+        SetupRepo(CodigoActivo(maxUses: null, expiresAt: null));
+
+        var result = await _service.ValidateAsync("TEST01");
+
+        result.Valid.Should().BeTrue();
+    }
+
+    // Normalización
+
+    [Fact]
+    public async Task ValidateAsync_CuandoCodigoEnMinusculas_ConsultaRepositorioUnaVez()
+    {
+        SetupRepo(CodigoActivo());
+
+        var result = await _service.ValidateAsync("test01");
+
+        result.Valid.Should().BeTrue();
+        _mockRepo.Verify(
+            r => r.FindAsync(It.IsAny<System.Linq.Expressions.Expression<Func<PromoCode, bool>>>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_CuandoCodigoMixto_ConsultaRepositorioUnaVez()
+    {
+        SetupRepo(null);
+
+        await _service.ValidateAsync("tEsT01");
+
+        _mockRepo.Verify(
+            r => r.FindAsync(It.IsAny<System.Linq.Expressions.Expression<Func<PromoCode, bool>>>()), Times.Once);
+    }
+}

--- a/DotNetEcuador.Tests/Validators/PromoCodeValidateRequestValidatorTests.cs
+++ b/DotNetEcuador.Tests/Validators/PromoCodeValidateRequestValidatorTests.cs
@@ -1,0 +1,76 @@
+using DotNetEcuador.API.Models.Eventos.DTOs;
+using DotNetEcuador.API.Validators.Eventos;
+using FluentValidation.TestHelper;
+
+namespace DotNetEcuador.Tests.Validators;
+
+public class PromoCodeValidateRequestValidatorTests
+{
+    private readonly PromoCodeValidateRequestValidator _validator = new();
+
+    // Request válido
+
+    [Theory]
+    [InlineData("ABC123")]
+    [InlineData("abc123")]
+    [InlineData("AAAAAA")]
+    [InlineData("999999")]
+    [InlineData("AbCd1E")]
+    [InlineData("TEST01")]
+    [InlineData("FREE99")]
+    public void Validate_CuandoCodigo6CaracteresAlfanumericos_NoTieneErrores(string code)
+    {
+        var result = _validator.TestValidate(new PromoCodeValidateRequestDto { Code = code });
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    // Código vacío o nulo
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void Validate_CuandoCodigoVacioONulo_TieneError(string? code)
+    {
+        var result = _validator.TestValidate(new PromoCodeValidateRequestDto { Code = code! });
+        result.ShouldHaveValidationErrorFor(x => x.Code);
+    }
+
+    // Longitud incorrecta
+
+    [Theory]
+    [InlineData("A")]
+    [InlineData("AB")]
+    [InlineData("ABC")]
+    [InlineData("ABCD")]
+    [InlineData("ABCDE")]
+    public void Validate_CuandoCodigoMenosDe6Caracteres_TieneError(string code)
+    {
+        var result = _validator.TestValidate(new PromoCodeValidateRequestDto { Code = code });
+        result.ShouldHaveValidationErrorFor(x => x.Code);
+    }
+
+    [Theory]
+    [InlineData("ABCDEFG")]
+    [InlineData("12345678")]
+    [InlineData("ABCDEFGHIJ")]
+    public void Validate_CuandoCodigoMasDe6Caracteres_TieneError(string code)
+    {
+        var result = _validator.TestValidate(new PromoCodeValidateRequestDto { Code = code });
+        result.ShouldHaveValidationErrorFor(x => x.Code);
+    }
+
+    // Caracteres no alfanuméricos
+
+    [Theory]
+    [InlineData("ABC!23")]
+    [InlineData("AB C12")]
+    [InlineData("AB-C12")]
+    [InlineData("AB.C12")]
+    [InlineData("AB_C12")]
+    [InlineData("ÁBC123")]
+    public void Validate_CuandoCodigoConCaracteresEspeciales_TieneError(string code)
+    {
+        var result = _validator.TestValidate(new PromoCodeValidateRequestDto { Code = code });
+        result.ShouldHaveValidationErrorFor(x => x.Code);
+    }
+}

--- a/promo_codes_seed.json
+++ b/promo_codes_seed.json
@@ -1,0 +1,20 @@
+[
+  {
+    "code": "TEST01",
+    "description": "TEST DATA - Código de prueba sin límite de usos",
+    "isActive": true,
+    "maxUses": null,
+    "currentUses": 0,
+    "expiresAt": null,
+    "createdAt": { "$date": "2026-01-01T00:00:00Z" }
+  },
+  {
+    "code": "FREE99",
+    "description": "TEST DATA - Código de prueba con límite de 99 usos",
+    "isActive": true,
+    "maxUses": 99,
+    "currentUses": 0,
+    "expiresAt": null,
+    "createdAt": { "$date": "2026-01-01T00:00:00Z" }
+  }
+]


### PR DESCRIPTION
 - Nuevo modelo PromoCode en MongoDB (colección promo_codes)
  - Endpoint POST /api/v1/promo-codes/validate — valida isActive, maxUses y expiresAt sin incrementar usos
  - Responde 200 con valid: true o 422 con mensaje de error
  - Seed con 2 códigos de prueba: TEST01 y FREE99

  Tests

  - 28 tests unitarios nuevos: PromoCodeServiceTests, PromoCodesControllerTests, PromoCodeValidateRequestValidatorTests
  - Cubren casos válidos, inválidos, borde de expiración, normalización a mayúsculas y propagación de excepciones
  - 128/128 pasando