### PR TITLE
Fix: new endpoint for apply promo

### DIFF
--- a/DotNetEcuador.API/Controllers/V1/RegistrosController.cs
+++ b/DotNetEcuador.API/Controllers/V1/RegistrosController.cs
@@ -76,6 +76,36 @@ public class RegistrosController : BaseApiController
     }
 
     /// <summary>
+    /// Aprueba automáticamente un registro que usó código promo. Requiere X-Session-Token en el header.
+    /// </summary>
+    [HttpPost("{id}/aplicar-promo")]
+    [ProducesResponseType(200)]
+    [ProducesResponseType(401)]
+    [ProducesResponseType(404)]
+    public async Task<IActionResult> AplicarPromo(
+        string id,
+        [FromBody] AplicarPromoRequestDto request,
+        [FromHeader(Name = "X-Session-Token")] string sessionToken)
+    {
+        if (string.IsNullOrEmpty(sessionToken))
+            return UnauthorizedError("Se requiere el header X-Session-Token.");
+
+        try
+        {
+            await _registroService.AplicarPromoAsync(id, sessionToken, request.Code).ConfigureAwait(false);
+            return SuccessResponse("Código promo aplicado. Tu acceso está confirmado.");
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return NotFoundError(ex.Message);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return UnauthorizedError(ex.Message);
+        }
+    }
+
+    /// <summary>
     /// Recupera el registro de un asistente por email y slug del evento
     /// </summary>
     [HttpGet("recuperar")]

--- a/DotNetEcuador.API/Infraestructure/Services/Eventos/IPromoCodeService.cs
+++ b/DotNetEcuador.API/Infraestructure/Services/Eventos/IPromoCodeService.cs
@@ -5,4 +5,5 @@ namespace DotNetEcuador.API.Infraestructure.Services.Eventos;
 public interface IPromoCodeService
 {
     Task<PromoCodeValidateResponseDto> ValidateAsync(string code);
+    Task IncrementUsesAsync(string code);
 }

--- a/DotNetEcuador.API/Infraestructure/Services/Eventos/IRegistroService.cs
+++ b/DotNetEcuador.API/Infraestructure/Services/Eventos/IRegistroService.cs
@@ -8,6 +8,7 @@ public interface IRegistroService
 {
     Task<RegistroResponseDto> CrearRegistroAsync(RegistroRequestDto request);
     Task SubirComprobanteAsync(string registroId, string sessionToken, ComprobanteRequestDto dto);
+    Task AplicarPromoAsync(string registroId, string sessionToken, string promoCode);
     Task<EventoEstadoDto> GetEstadoAsync(string registroId);
     Task<PagedResponse<AdminRegistroDto>> GetAdminRegistrosAsync(PagedRequest request, string? eventoId, string? estado);
     Task AprobarAsync(string registroId, string notasAdmin);

--- a/DotNetEcuador.API/Infraestructure/Services/Eventos/PromoCodeService.cs
+++ b/DotNetEcuador.API/Infraestructure/Services/Eventos/PromoCodeService.cs
@@ -43,6 +43,22 @@ public class PromoCodeService : IPromoCodeService
         };
     }
 
+    public async Task IncrementUsesAsync(string code)
+    {
+        var upperCode = code.ToUpperInvariant();
+
+        var promoCode = await _promoCodeRepository.FindAsync(p =>
+            p.Code == upperCode &&
+            p.IsActive).ConfigureAwait(false);
+
+        if (promoCode is null) return;
+
+        promoCode.CurrentUses++;
+        await _promoCodeRepository.UpdateAsync(promoCode.Id, promoCode).ConfigureAwait(false);
+
+        _logger.LogInformation("Promo code {Code} uses incremented to {Count}", upperCode, promoCode.CurrentUses);
+    }
+
     private static PromoCodeValidateResponseDto Invalid() =>
         new() { Valid = false, Message = "Código no válido o expirado." };
 }

--- a/DotNetEcuador.API/Infraestructure/Services/Eventos/RegistroService.cs
+++ b/DotNetEcuador.API/Infraestructure/Services/Eventos/RegistroService.cs
@@ -18,6 +18,7 @@ public class RegistroService : IRegistroService
     private readonly IRepository<EmailLog> _emailLogRepo;
     private readonly IFileStorageService _fileStorage;
     private readonly ITelegramBotService _telegramBot;
+    private readonly IPromoCodeService _promoCodeService;
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<RegistroService> _logger;
     private readonly string _uploadsPath;
@@ -33,6 +34,7 @@ public class RegistroService : IRegistroService
         IRepository<EmailLog> emailLogRepo,
         IFileStorageService fileStorage,
         ITelegramBotService telegramBot,
+        IPromoCodeService promoCodeService,
         IServiceScopeFactory scopeFactory,
         ILogger<RegistroService> logger)
     {
@@ -44,6 +46,7 @@ public class RegistroService : IRegistroService
         _emailLogRepo = emailLogRepo;
         _fileStorage = fileStorage;
         _telegramBot = telegramBot;
+        _promoCodeService = promoCodeService;
         _scopeFactory = scopeFactory;
         _logger = logger;
         _uploadsPath = Environment.GetEnvironmentVariable("UPLOADS_PATH")
@@ -258,6 +261,55 @@ public class RegistroService : IRegistroService
             registroId, TipoEmail.ConfirmacionPagada, asistente.Email).ConfigureAwait(false);
 
         _logger.LogInformation("Registro {IdCorto} aprobado para {Email}", registro.IdCorto, asistente.Email);
+    }
+
+    public async Task AplicarPromoAsync(string registroId, string sessionToken, string promoCode)
+    {
+        var registro = await _registroRepo.GetByIdAsync(registroId).ConfigureAwait(false)
+            ?? throw new KeyNotFoundException("Registro no encontrado.");
+
+        if (registro.SessionToken != sessionToken)
+            throw new UnauthorizedAccessException("Session token inválido.");
+
+        registro.Estado = EstadoRegistro.Pagado;
+        registro.ConfirmadoEn = AhoraEcuador();
+        await _registroRepo.UpdateAsync(registroId, registro).ConfigureAwait(false);
+
+        try
+        {
+            await _promoCodeService.IncrementUsesAsync(promoCode).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error incrementando usos de código promo {Code}", promoCode);
+        }
+
+        var asistente = await _asistenteRepo.GetByIdAsync(registro.AsistenteId).ConfigureAwait(false);
+        if (asistente is null) return;
+
+        var eventos = await _eventoService.GetAllAsync().ConfigureAwait(false);
+        var evento = eventos.FirstOrDefault(e => e.Id == registro.EventoId);
+        if (evento is null) return;
+
+        var qrBase64 = _qrService.GenerarQrBase64(registro.TokenQr);
+
+        await EnviarEmailSeguroAsync(async () =>
+            await _emailService.EnviarConfirmacionPagadaAsync(registro, asistente, evento, qrBase64).ConfigureAwait(false),
+            registroId, TipoEmail.ConfirmacionPagada, asistente.Email).ConfigureAwait(false);
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await _telegramBot.NotificarPromoAplicadoAsync(registro, asistente, evento).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error enviando notificación Telegram para promo registro {IdCorto}", registro.IdCorto);
+            }
+        });
+
+        _logger.LogInformation("Registro {IdCorto} aprobado via promo code para {Email}", registro.IdCorto, asistente.Email);
     }
 
     public async Task RechazarAsync(string registroId, string motivo)

--- a/DotNetEcuador.API/Infraestructure/Services/Telegram/ITelegramBotService.cs
+++ b/DotNetEcuador.API/Infraestructure/Services/Telegram/ITelegramBotService.cs
@@ -6,5 +6,6 @@ namespace DotNetEcuador.API.Infraestructure.Services.Telegram;
 public interface ITelegramBotService
 {
     Task NotificarComprobanteAsync(Registro registro, Asistente asistente, Evento evento, string rutaArchivo);
+    Task NotificarPromoAplicadoAsync(Registro registro, Asistente asistente, Evento evento);
     Task NotificarNuevoVoluntarioAsync(VolunteerApplication app);
 }

--- a/DotNetEcuador.API/Infraestructure/Services/Telegram/NullTelegramBotService.cs
+++ b/DotNetEcuador.API/Infraestructure/Services/Telegram/NullTelegramBotService.cs
@@ -8,6 +8,9 @@ public class NullTelegramBotService : ITelegramBotService
     public Task NotificarComprobanteAsync(Registro registro, Asistente asistente, Evento evento, string rutaArchivo)
         => Task.CompletedTask;
 
+    public Task NotificarPromoAplicadoAsync(Registro registro, Asistente asistente, Evento evento)
+        => Task.CompletedTask;
+
     public Task NotificarNuevoVoluntarioAsync(VolunteerApplication app)
         => Task.CompletedTask;
 }

--- a/DotNetEcuador.API/Infraestructure/Services/Telegram/TelegramBotService.cs
+++ b/DotNetEcuador.API/Infraestructure/Services/Telegram/TelegramBotService.cs
@@ -80,6 +80,23 @@ public class TelegramBotService : ITelegramBotService
         }
     }
 
+    public async Task NotificarPromoAplicadoAsync(Registro registro, Asistente asistente, Evento evento)
+    {
+        if (_adminChatId == 0) return;
+
+        var texto = $"🎟️ *Registro con código promo*\n\n" +
+                    $"*Evento:* {EscaparMarkdown(evento.Nombre)}\n" +
+                    $"*Asistente:* {EscaparMarkdown(asistente.Nombre)}\n" +
+                    $"*Email:* {EscaparMarkdown(asistente.Email)}\n" +
+                    $"*ID Corto:* `{registro.IdCorto}`\n" +
+                    $"*Estado:* Aprobado automáticamente";
+
+        await _bot.SendMessage(
+            chatId: _adminChatId,
+            text: texto,
+            parseMode: ParseMode.Markdown).ConfigureAwait(false);
+    }
+
     public async Task NotificarNuevoVoluntarioAsync(VolunteerApplication app)
     {
         if (_adminChatId == 0) return;

--- a/DotNetEcuador.API/Models/Eventos/DTOs/PromoCodeDtos.cs
+++ b/DotNetEcuador.API/Models/Eventos/DTOs/PromoCodeDtos.cs
@@ -10,3 +10,8 @@ public class PromoCodeValidateResponseDto
     public bool Valid { get; set; }
     public string Message { get; set; } = string.Empty;
 }
+
+public class AplicarPromoRequestDto
+{
+    public string Code { get; set; } = string.Empty;
+}

--- a/DotNetEcuador.API/Validators/Eventos/AplicarPromoRequestValidator.cs
+++ b/DotNetEcuador.API/Validators/Eventos/AplicarPromoRequestValidator.cs
@@ -1,0 +1,15 @@
+using DotNetEcuador.API.Models.Eventos.DTOs;
+using FluentValidation;
+
+namespace DotNetEcuador.API.Validators.Eventos;
+
+public class AplicarPromoRequestValidator : AbstractValidator<AplicarPromoRequestDto>
+{
+    public AplicarPromoRequestValidator()
+    {
+        RuleFor(x => x.Code)
+            .NotEmpty().WithMessage("El código es requerido.")
+            .Length(6).WithMessage("El código debe tener exactamente 6 caracteres.")
+            .Matches("^[A-Za-z0-9]{6}$").WithMessage("El código solo puede contener letras y números.");
+    }
+}

--- a/DotNetEcuador.Tests/Controllers/RegistrosControllerTests.cs
+++ b/DotNetEcuador.Tests/Controllers/RegistrosControllerTests.cs
@@ -1,0 +1,148 @@
+using DotNetEcuador.API.Controllers.V1;
+using DotNetEcuador.API.Infraestructure.Services.Eventos;
+using DotNetEcuador.API.Models.Common;
+using DotNetEcuador.API.Models.Eventos.DTOs;
+using DotNetEcuador.API.Services;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace DotNetEcuador.Tests.Controllers;
+
+public class RegistrosControllerTests
+{
+    private readonly Mock<IRegistroService> _mockService;
+    private readonly Mock<IMessageService> _mockMessageService;
+    private readonly Mock<ILogger<RegistrosController>> _mockLogger;
+    private readonly RegistrosController _controller;
+
+    public RegistrosControllerTests()
+    {
+        _mockService = new Mock<IRegistroService>();
+        _mockMessageService = new Mock<IMessageService>();
+        _mockLogger = new Mock<ILogger<RegistrosController>>();
+
+        _controller = new RegistrosController(
+            _mockService.Object,
+            _mockMessageService.Object,
+            _mockLogger.Object);
+
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext()
+        };
+    }
+
+    private static AplicarPromoRequestDto PromoRequest(string code = "TEST01") => new() { Code = code };
+
+    // AplicarPromo — sin session token
+
+    [Fact]
+    public async Task AplicarPromo_CuandoSessionTokenVacio_RetornaStatus401()
+    {
+        var result = await _controller.AplicarPromo("reg-id", PromoRequest(), string.Empty);
+
+        result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(401);
+    }
+
+    [Fact]
+    public async Task AplicarPromo_CuandoSessionTokenNulo_RetornaStatus401()
+    {
+        var result = await _controller.AplicarPromo("reg-id", PromoRequest(), null!);
+
+        result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(401);
+    }
+
+    // AplicarPromo — servicio exitoso
+
+    [Fact]
+    public async Task AplicarPromo_CuandoValido_RetornaStatus200()
+    {
+        _mockService.Setup(s => s.AplicarPromoAsync("reg-id", "token-ok", "TEST01")).Returns(Task.CompletedTask);
+
+        var result = await _controller.AplicarPromo("reg-id", PromoRequest(), "token-ok");
+
+        result.Should().BeOfType<OkObjectResult>()
+            .Which.StatusCode.Should().Be(200);
+    }
+
+    [Fact]
+    public async Task AplicarPromo_CuandoValido_CuerpoEsApiResponse()
+    {
+        _mockService.Setup(s => s.AplicarPromoAsync("reg-id", "token-ok", "TEST01")).Returns(Task.CompletedTask);
+
+        var result = await _controller.AplicarPromo("reg-id", PromoRequest(), "token-ok");
+
+        var okResult = result.Should().BeOfType<OkObjectResult>().Subject;
+        okResult.Value.Should().BeOfType<ApiResponse>();
+    }
+
+    [Fact]
+    public async Task AplicarPromo_CuandoValido_MensajeConfirmacion()
+    {
+        _mockService.Setup(s => s.AplicarPromoAsync("reg-id", "token-ok", "TEST01")).Returns(Task.CompletedTask);
+
+        var result = await _controller.AplicarPromo("reg-id", PromoRequest(), "token-ok");
+
+        var okResult = (OkObjectResult)result;
+        var response = (ApiResponse)okResult.Value!;
+        response.Message.Should().Be("Código promo aplicado. Tu acceso está confirmado.");
+    }
+
+    // AplicarPromo — registro no encontrado
+
+    [Fact]
+    public async Task AplicarPromo_CuandoRegistroNoExiste_RetornaStatus404()
+    {
+        _mockService.Setup(s => s.AplicarPromoAsync("no-existe", "token-ok", "TEST01"))
+            .ThrowsAsync(new KeyNotFoundException("Registro no encontrado."));
+
+        var result = await _controller.AplicarPromo("no-existe", PromoRequest(), "token-ok");
+
+        result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(404);
+    }
+
+    // AplicarPromo — token inválido
+
+    [Fact]
+    public async Task AplicarPromo_CuandoTokenInvalido_RetornaStatus401()
+    {
+        _mockService.Setup(s => s.AplicarPromoAsync("reg-id", "token-malo", "TEST01"))
+            .ThrowsAsync(new UnauthorizedAccessException("Session token inválido."));
+
+        var result = await _controller.AplicarPromo("reg-id", PromoRequest(), "token-malo");
+
+        result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(401);
+    }
+
+    // AplicarPromo — delegación al servicio
+
+    [Fact]
+    public async Task AplicarPromo_PasaIdTokenYCodigoExactosAlServicio()
+    {
+        _mockService.Setup(s => s.AplicarPromoAsync("reg-abc", "my-token", "ABCD12")).Returns(Task.CompletedTask);
+
+        await _controller.AplicarPromo("reg-abc", PromoRequest("ABCD12"), "my-token");
+
+        _mockService.Verify(s => s.AplicarPromoAsync("reg-abc", "my-token", "ABCD12"), Times.Once);
+    }
+
+    [Fact]
+    public async Task AplicarPromo_LlamaAlServicioExactamenteUnaVez()
+    {
+        _mockService.Setup(s => s.AplicarPromoAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Returns(Task.CompletedTask);
+
+        await _controller.AplicarPromo("reg-id", PromoRequest(), "token-ok");
+
+        _mockService.Verify(s => s.AplicarPromoAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+    }
+}

--- a/DotNetEcuador.Tests/Services/Eventos/PromoCodeServiceTests.cs
+++ b/DotNetEcuador.Tests/Services/Eventos/PromoCodeServiceTests.cs
@@ -163,4 +163,55 @@ public class PromoCodeServiceTests
         _mockRepo.Verify(
             r => r.FindAsync(It.IsAny<System.Linq.Expressions.Expression<Func<PromoCode, bool>>>()), Times.Once);
     }
+
+    // IncrementUsesAsync
+
+    [Fact]
+    public async Task IncrementUsesAsync_CuandoCodigoNoExiste_NoLanzaExcepcion()
+    {
+        SetupRepo(null);
+
+        await _service.IncrementUsesAsync("NOEXST");
+    }
+
+    [Fact]
+    public async Task IncrementUsesAsync_CuandoCodigoExiste_IncrementaCurrentUses()
+    {
+        var promoCode = CodigoActivo(currentUses: 3);
+        SetupRepo(promoCode);
+        _mockRepo.Setup(r => r.UpdateAsync(promoCode.Id, It.IsAny<PromoCode>())).Returns(Task.CompletedTask);
+
+        await _service.IncrementUsesAsync("TEST01");
+
+        _mockRepo.Verify(
+            r => r.UpdateAsync(promoCode.Id, It.Is<PromoCode>(p => p.CurrentUses == 4)),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task IncrementUsesAsync_CuandoCodigoExiste_LlamaUpdateAsync()
+    {
+        var promoCode = CodigoActivo();
+        SetupRepo(promoCode);
+        _mockRepo.Setup(r => r.UpdateAsync(It.IsAny<string>(), It.IsAny<PromoCode>())).Returns(Task.CompletedTask);
+
+        await _service.IncrementUsesAsync("TEST01");
+
+        _mockRepo.Verify(
+            r => r.UpdateAsync(promoCode.Id, It.IsAny<PromoCode>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task IncrementUsesAsync_NormalizaCodigoAMayusculas()
+    {
+        var promoCode = CodigoActivo();
+        SetupRepo(promoCode);
+        _mockRepo.Setup(r => r.UpdateAsync(It.IsAny<string>(), It.IsAny<PromoCode>())).Returns(Task.CompletedTask);
+
+        await _service.IncrementUsesAsync("test01");
+
+        _mockRepo.Verify(
+            r => r.FindAsync(It.IsAny<System.Linq.Expressions.Expression<Func<PromoCode, bool>>>()), Times.Once);
+    }
 }

--- a/DotNetEcuador.Tests/Services/Eventos/RegistroServiceTests.cs
+++ b/DotNetEcuador.Tests/Services/Eventos/RegistroServiceTests.cs
@@ -21,6 +21,7 @@ public class RegistroServiceTests
     private readonly Mock<IRepository<EmailLog>> _mockEmailLogRepo;
     private readonly Mock<IFileStorageService> _mockFileStorage;
     private readonly Mock<ITelegramBotService> _mockTelegramBot;
+    private readonly Mock<IPromoCodeService> _mockPromoCodeService;
     private readonly Mock<IServiceScopeFactory> _mockScopeFactory;
     private readonly Mock<ILogger<RegistroService>> _mockLogger;
     private readonly IRegistroService _service;
@@ -35,6 +36,7 @@ public class RegistroServiceTests
         _mockEmailLogRepo = new Mock<IRepository<EmailLog>>();
         _mockFileStorage = new Mock<IFileStorageService>();
         _mockTelegramBot = new Mock<ITelegramBotService>();
+        _mockPromoCodeService = new Mock<IPromoCodeService>();
         _mockScopeFactory = new Mock<IServiceScopeFactory>();
         _mockLogger = new Mock<ILogger<RegistroService>>();
 
@@ -53,6 +55,7 @@ public class RegistroServiceTests
             _mockEmailLogRepo.Object,
             _mockFileStorage.Object,
             _mockTelegramBot.Object,
+            _mockPromoCodeService.Object,
             _mockScopeFactory.Object,
             _mockLogger.Object);
     }
@@ -183,6 +186,152 @@ public class RegistroServiceTests
         _mockEventoService.Setup(s => s.GetAllAsync()).ReturnsAsync(new List<Evento>());
 
         await _service.SubirComprobanteAsync(registroId, "token-valido", new ComprobanteRequestDto());
+    }
+
+    [Fact]
+    public async Task AplicarPromo_CuandoRegistroNoExiste_LanzaKeyNotFoundException()
+    {
+        _mockRegistroRepo.Setup(r => r.GetByIdAsync("no-existe")).ReturnsAsync((Registro?)null);
+
+        await Assert.ThrowsAsync<KeyNotFoundException>(() =>
+            _service.AplicarPromoAsync("no-existe", "any-token", "TEST01"));
+    }
+
+    [Fact]
+    public async Task AplicarPromo_CuandoSessionTokenInvalido_LanzaUnauthorizedAccessException()
+    {
+        var registro = new Registro
+        {
+            Id = "507f1f77bcf86cd799439011",
+            SessionToken = "token-valido",
+            Estado = EstadoRegistro.Pendiente
+        };
+        _mockRegistroRepo.Setup(r => r.GetByIdAsync("507f1f77bcf86cd799439011")).ReturnsAsync(registro);
+
+        await Assert.ThrowsAsync<UnauthorizedAccessException>(() =>
+            _service.AplicarPromoAsync("507f1f77bcf86cd799439011", "token-incorrecto", "TEST01"));
+    }
+
+    [Fact]
+    public async Task AplicarPromo_CuandoValido_SetaEstadoPagado()
+    {
+        var registroId = "507f1f77bcf86cd799439011";
+        var registro = new Registro
+        {
+            Id = registroId,
+            AsistenteId = "507f1f77bcf86cd799439012",
+            EventoId = "507f1f77bcf86cd799439013",
+            SessionToken = "token-valido",
+            TokenQr = "qr-token",
+            Estado = EstadoRegistro.Pendiente,
+            IdCorto = "TEST01"
+        };
+        Registro? registroActualizado = null;
+        _mockRegistroRepo.Setup(r => r.GetByIdAsync(registroId)).ReturnsAsync(registro);
+        _mockRegistroRepo.Setup(r => r.UpdateAsync(registroId, It.IsAny<Registro>()))
+            .Callback<string, Registro>((_, r) => registroActualizado = r)
+            .Returns(Task.CompletedTask);
+        _mockAsistenteRepo.Setup(r => r.GetByIdAsync(registro.AsistenteId)).ReturnsAsync((Asistente?)null);
+
+        await _service.AplicarPromoAsync(registroId, "token-valido", "TEST01");
+
+        registroActualizado!.Estado.Should().Be(EstadoRegistro.Pagado);
+        registroActualizado.ConfirmadoEn.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task AplicarPromo_CuandoValido_IncrementaUsosDelCodigo()
+    {
+        var registroId = "507f1f77bcf86cd799439011";
+        var registro = new Registro
+        {
+            Id = registroId,
+            AsistenteId = "507f1f77bcf86cd799439012",
+            SessionToken = "token-valido",
+            Estado = EstadoRegistro.Pendiente
+        };
+        _mockRegistroRepo.Setup(r => r.GetByIdAsync(registroId)).ReturnsAsync(registro);
+        _mockRegistroRepo.Setup(r => r.UpdateAsync(registroId, It.IsAny<Registro>())).Returns(Task.CompletedTask);
+        _mockAsistenteRepo.Setup(r => r.GetByIdAsync(registro.AsistenteId)).ReturnsAsync((Asistente?)null);
+
+        await _service.AplicarPromoAsync(registroId, "token-valido", "TEST01");
+
+        _mockPromoCodeService.Verify(s => s.IncrementUsesAsync("TEST01"), Times.Once);
+    }
+
+    [Fact]
+    public async Task AplicarPromo_CuandoAsistenoNoExiste_RetornaSinError()
+    {
+        var registroId = "507f1f77bcf86cd799439011";
+        var registro = new Registro
+        {
+            Id = registroId,
+            AsistenteId = "507f1f77bcf86cd799439012",
+            SessionToken = "token-valido",
+            Estado = EstadoRegistro.Pendiente
+        };
+        _mockRegistroRepo.Setup(r => r.GetByIdAsync(registroId)).ReturnsAsync(registro);
+        _mockRegistroRepo.Setup(r => r.UpdateAsync(registroId, It.IsAny<Registro>())).Returns(Task.CompletedTask);
+        _mockAsistenteRepo.Setup(r => r.GetByIdAsync(registro.AsistenteId)).ReturnsAsync((Asistente?)null);
+
+        await _service.AplicarPromoAsync(registroId, "token-valido", "TEST01");
+    }
+
+    [Fact]
+    public async Task AplicarPromo_CuandoEventoNoExiste_RetornaSinError()
+    {
+        var registroId = "507f1f77bcf86cd799439011";
+        var registro = new Registro
+        {
+            Id = registroId,
+            AsistenteId = "507f1f77bcf86cd799439012",
+            EventoId = "507f1f77bcf86cd799439013",
+            SessionToken = "token-valido",
+            Estado = EstadoRegistro.Pendiente
+        };
+        var asistente = new Asistente { Id = "507f1f77bcf86cd799439012", Email = "juan@test.com", Nombre = "Juan" };
+        _mockRegistroRepo.Setup(r => r.GetByIdAsync(registroId)).ReturnsAsync(registro);
+        _mockRegistroRepo.Setup(r => r.UpdateAsync(registroId, It.IsAny<Registro>())).Returns(Task.CompletedTask);
+        _mockAsistenteRepo.Setup(r => r.GetByIdAsync(registro.AsistenteId)).ReturnsAsync(asistente);
+        _mockEventoService.Setup(s => s.GetAllAsync()).ReturnsAsync(new List<Evento>());
+
+        await _service.AplicarPromoAsync(registroId, "token-valido", "TEST01");
+    }
+
+    [Fact]
+    public async Task AplicarPromo_CuandoValido_EnviaEmailQrAlAsistente()
+    {
+        var registroId = "507f1f77bcf86cd799439011";
+        var registro = new Registro
+        {
+            Id = registroId,
+            AsistenteId = "507f1f77bcf86cd799439012",
+            EventoId = "507f1f77bcf86cd799439013",
+            SessionToken = "token-valido",
+            TokenQr = "qr-token",
+            Estado = EstadoRegistro.Pendiente,
+            IdCorto = "TEST01"
+        };
+        var asistente = new Asistente { Id = "507f1f77bcf86cd799439012", Email = "juan@test.com", Nombre = "Juan" };
+        var evento = EventoConCupo();
+        evento.Id = "507f1f77bcf86cd799439013";
+
+        _mockRegistroRepo.Setup(r => r.GetByIdAsync(registroId)).ReturnsAsync(registro);
+        _mockRegistroRepo.Setup(r => r.UpdateAsync(registroId, It.IsAny<Registro>())).Returns(Task.CompletedTask);
+        _mockAsistenteRepo.Setup(r => r.GetByIdAsync(registro.AsistenteId)).ReturnsAsync(asistente);
+        _mockEventoService.Setup(s => s.GetAllAsync()).ReturnsAsync(new List<Evento> { evento });
+        _mockQrService.Setup(s => s.GenerarQrBase64(It.IsAny<string>())).Returns("qr-base64");
+        _mockEmailService
+            .Setup(s => s.EnviarConfirmacionPagadaAsync(
+                It.IsAny<Registro>(), It.IsAny<Asistente>(), It.IsAny<Evento>(), It.IsAny<string>()))
+            .Returns(Task.CompletedTask);
+
+        await _service.AplicarPromoAsync(registroId, "token-valido", "TEST01");
+
+        _mockEmailService.Verify(
+            s => s.EnviarConfirmacionPagadaAsync(
+                It.IsAny<Registro>(), It.IsAny<Asistente>(), It.IsAny<Evento>(), "qr-base64"),
+            Times.Once);
     }
 
     [Fact]


### PR DESCRIPTION
 Fix: Nuevo endpoint POST /api/v1/registros/{id}/aplicar-promo que:
  - Valida el session token
  - Marca el registro como Pagado
  - Envía el email con QR al asistente
  - Notifica al admin por Telegram ("Registro con código promo")